### PR TITLE
Precedence of function application and accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
   - [ ] imports
     - [ ] check for unbound variables to avoid capture issues
   - [ ] warnings
-  - [ ] fix precedence issue (`builtins.fix (self: 0)` fails)
+  - [x] fix precedence issue (`builtins.fix (self: 0)` fails)
   - [ ] benchmarks
     - [ ] use Text instead of String
   - [ ] inherit from set, inherit multiple

--- a/src/Parse.hs
+++ b/src/Parse.hs
@@ -82,10 +82,10 @@ pInherit = do
 -- first try to parse term as app
 -- TODO is this a hack?
 pExpr :: Parser Expr
-pExpr = pLam <|> pFunc <|> pLet <|> makeExprParser pTerm operatorTable
+pExpr = choice [pLet, pLam, pFunc, makeExprParser pTerm operatorTable]
   where
     -- TODO the try before pAttrs here is so allow it to parse the block expression if it fails
-    pTerm1 =
+    pTerm =
       choice
         [ parens pExpr,
           pList,
@@ -94,10 +94,10 @@ pExpr = pLam <|> pFunc <|> pLet <|> makeExprParser pTerm operatorTable
           Var <$> pName, -- TODO turn back into pVar
           Lit <$> pLit -- TODO turn back into pLit
         ]
-    pTerm = foldl1 App <$> some pTerm1 -- TODO foldl
     operatorTable :: [[Operator Parser Expr]]
     operatorTable =
       [ [repeatedPostfix pFieldAcc],
+        [InfixL (pure App)], -- function call
         [arith "*" Mul],
         [arith "+" Add, arith "-" Sub]
       ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -95,7 +95,7 @@ evalTests =
           "let x = builtins.undefined; y = builtins.nine; in y"
         ),
         ( "fix",
-          "let attr = (builtins.fix) (self: { \
+          "let attr = builtins.fix (self: { \
           \      three: 3, \
           \      nine: self.three * self.three}); \
           \ in attr.nine"


### PR DESCRIPTION
This PR fixes the precedence of function application (space) and method accessors (.) by treating function application as a left-associative operator.